### PR TITLE
Release/3.0.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = AppConfig.appId
         minSdk = AppConfig.minSdkVersion
         targetSdk = AppConfig.targetSdkVersion
-        versionCode = 17
-        versionName = "3.0.0"
+        versionCode = 20
+        versionName = "3.0.1"
         vectorDrawables.useSupportLibrary = true
         androidResources {
             localeFilters += listOf("en", "de", "pt-rBR", "tr")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,12 +15,13 @@
     <application
         android:name=".SysctlGuiApp"
         android:allowBackup="false"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:enableOnBackInvokedCallback="true"
         tools:ignore="GoogleAppIndexingWarning">
         <activity android:name=".ui.main.MainActivity" />
         <activity

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="de" />
+    <locale android:name="pt-rBR" />
+    <locale android:name="tr" />
+</locale-config>

--- a/buildSrc/src/main/kotlin/AppConfig.kt
+++ b/buildSrc/src/main/kotlin/AppConfig.kt
@@ -1,5 +1,5 @@
 object AppConfig {
-    val devCycle = true
+    val devCycle = false
 
     const val appId = "com.androidvip.sysctlgui"
     const val compileSdkVersion = 36


### PR DESCRIPTION
- Added per-app language support (Android 13+)
- Improved StartUpWorker reliability (fixes reapply on boot)

Addresses #71 by commiting proper `versionCode` and `versionName` to the repository  as well as changing `devCycle` to `true`, this means a regular "release" build will be _minified_ and non-debuggable.